### PR TITLE
Make `mypy` optional + add `py.typed`

### DIFF
--- a/src/scicookie/hooks/post_gen_project.py
+++ b/src/scicookie/hooks/post_gen_project.py
@@ -31,6 +31,7 @@ USE_BANDIT = {{ cookiecutter.use_bandit == "yes" }}
 USE_CONTAINERS = {{ cookiecutter.use_containers in ['Docker', 'Podman'] }}
 USE_CLI = {{ cookiecutter.command_line_interface != "No command-line interface" }}
 USE_CONDA = {{ cookiecutter.use_conda == "yes" }}
+USE_MYPY = {{ cookiecutter.use_mypy == "yes" }}
 {% if cookiecutter.code_of_conduct == "contributor-covenant" -%}
 COC_PATH = PROJECT_DIRECTORY / 'coc' / 'CONTRIBUTOR_COVENANT.md'
 {%- elif cookiecutter.code_of_conduct == "citizen-code-of-conduct" -%}
@@ -97,6 +98,7 @@ def move_selected_doc_dir():
         remove_project_file(Path("docs/api") / "references.md")
 
     shutil.rmtree(DOCS_SPEC_DIR)
+
 
 def clean_up_docs():
     remove_dirs(UNUSED_DOCS_DIRS)
@@ -205,6 +207,7 @@ def clean_up_build_system():
         )
     remove_dir("build-system")
 
+
 def http2ssh(url):
     url = url.replace("https://", "git@")
     return url.replace("/", ":", 1)
@@ -262,7 +265,12 @@ def add_binding_source_files():
             os.makedir(src_system_dir)
             shutil.move(build_system_dir / "lib.rs", src_system_dir)
     else:
-        pass   
+        pass
+
+
+def clean_up_mypy():
+    if not USE_MYPY: remove_package_file("py.typed")
+
 
 def post_gen():
     validation()
@@ -271,6 +279,7 @@ def post_gen():
     clean_up_project_layout()
     add_binding_source_files()
     clean_up_cli()
+    clean_up_mypy()
     clean_up_code_of_conduct()
     clean_up_conda()
     clean_up_containers()

--- a/src/scicookie/hooks/post_gen_project.py
+++ b/src/scicookie/hooks/post_gen_project.py
@@ -269,7 +269,8 @@ def add_binding_source_files():
 
 
 def clean_up_mypy():
-    if not USE_MYPY: remove_package_file("py.typed")
+    if not USE_MYPY:
+        remove_package_file("py.typed")
 
 
 def post_gen():

--- a/src/scicookie/profiles/base.yaml
+++ b/src/scicookie/profiles/base.yaml
@@ -124,6 +124,7 @@ use_tools:
     - ruff
     - isort
     - mccabe
+    - mypy
     - pre-commit
     - pydocstyle
     - pytest

--- a/src/scicookie/{{cookiecutter.project_slug}}/.gitignore
+++ b/src/scicookie/{{cookiecutter.project_slug}}/.gitignore
@@ -98,8 +98,10 @@ docs/_build/
 docs/_templates/
 {%+ endif %}
 
+{%- if cookiecutter.use_mypy == "yes" %}
 # mypy
 .mypy_cache/
+{%- endif %}
 
 # IDE settings
 .vscode/

--- a/src/scicookie/{{cookiecutter.project_slug}}/conda/dev.yaml
+++ b/src/scicookie/{{cookiecutter.project_slug}}/conda/dev.yaml
@@ -26,3 +26,6 @@ dependencies:
 {%- if cookiecutter.documentation_engine == "sphinx" %}
   - pandoc
 {%- endif %}
+{%- if cookiecutter.use_mypy == "yes" %}
+  - mypy
+{%- endif %}

--- a/src/scicookie/{{cookiecutter.project_slug}}/{{cookiecutter.package_slug}}/__init__.py
+++ b/src/scicookie/{{cookiecutter.project_slug}}/{{cookiecutter.package_slug}}/__init__.py
@@ -10,7 +10,7 @@
 from importlib import metadata as importlib_metadata
 
 
-def get_version() -> str:
+def get_version():
     """Return the program version."""
     try:
         return importlib_metadata.version(__name__)
@@ -18,8 +18,8 @@ def get_version() -> str:
         return {{ QUOTE }}{{ cookiecutter.project_version }}{{ QUOTE }}  # semantic-release
 
 
-version: str = get_version()
+version = get_version()
 
 __author__ = {{ QUOTE }}{{ cookiecutter.author_full_name }}{{ QUOTE }}
 __email__ = {{ QUOTE }}{{ cookiecutter.author_email }}{{ QUOTE }}
-__version__: str = version
+__version__ = version

--- a/src/scicookie/{{cookiecutter.project_slug}}/{{cookiecutter.package_slug}}/__init__.py
+++ b/src/scicookie/{{cookiecutter.project_slug}}/{{cookiecutter.package_slug}}/__init__.py
@@ -1,4 +1,6 @@
+{%- if cookiecutter.use_mypy == "yes" %}
 # mypy: disable-error-code="attr-defined"
+{%- endif %}
 """{{ cookiecutter.project_name }}."""
 {%- if cookiecutter.use_blue == "yes" %}
   {%- set QUOTE = "'" -%}

--- a/src/scicookie/{{cookiecutter.project_slug}}/{{cookiecutter.package_slug}}/__init__.py
+++ b/src/scicookie/{{cookiecutter.project_slug}}/{{cookiecutter.package_slug}}/__init__.py
@@ -1,7 +1,7 @@
+"""{{ cookiecutter.project_name }}."""
 {%- if cookiecutter.use_mypy == "yes" %}
 # mypy: disable-error-code="attr-defined"
 {%- endif %}
-"""{{ cookiecutter.project_name }}."""
 {%- if cookiecutter.use_blue == "yes" %}
   {%- set QUOTE = "'" -%}
 {%- elif cookiecutter.use_black == "yes" %}


### PR DESCRIPTION
## Pull Request description

- `mypy` now appears in the TUI as an option
- `py.typed` is added by default but removed if `mypy` is not selected
- I've also removed the type signatures in the package codebase, to make `mypy` optional

Fixes #155
Fixes #157

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

* ```...```

<!-- Modify the options to suit your project. -->
## Pull Request checklists

This PR is a:
- [x] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:
- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
