### PR TITLE
feat: Add help information to the TUI

### DIFF
--- a/src/scicookie/profiles/base.yaml
+++ b/src/scicookie/profiles/base.yaml
@@ -1,62 +1,62 @@
 author_full_name:
-  message: Author's name
-  help: See more at https://
+  message: Type the author's name
+  help: https://osl-incubator.github.io/scicookie/guide.html#information-about-the-project
   type: text
   default: Roronoa Zoro
   enabled: true
 
 author_email:
-  message: Author's email
-  help: ""
+  message: Type the author's email
+  help: https://osl-incubator.github.io/scicookie/guide.html#information-about-the-project
   type: text
   default: zoro@one.piece
   enabled: true
 
 project_name:
-  message: Project name the title of the project
-  help: ""
+  message: Type the project's title
+  help: https://osl-incubator.github.io/scicookie/guide.html#information-about-the-project
   type: text
   default: OSL Python package
   enabled: true
 
 project_short_description:
-  message: Project short description
-  help: ""
+  message: Type a short description about the project
+  help: https://osl-incubator.github.io/scicookie/guide.html#information-about-the-project
   type: text
   default: This Project aims to ...
   enabled: true
 
 project_slug:
-  message: Project slug the code name for your project
-  help: ""
+  message: Type the code name for your project (e.g. the repository name)
+  help: https://osl-incubator.github.io/scicookie/guide.html#information-about-the-project
   type: text
   default: osl-template
   enabled: true
 
 package_slug:
-  message: Package slug the code name for your package
-  help: ""
+  message: Type the code name for your package (the name used to import your package)
+  help: https://osl-incubator.github.io/scicookie/guide.html#information-about-the-project
   type: text
-  default: osl_template
+  default: "{{project_slug.replace('-', '_')}}"
   enabled: true
 
 project_version:
-  message: Project version
-  help: ""
+  message: Type the project version
+  help: https://osl-incubator.github.io/scicookie/guide.html#information-about-the-project
   type: text
   default: 0.1.0
   enabled: true
 
 project_url:
-  message: Project URL
-  help: ""
+  message: Type the project URL
+  help: https://osl-incubator.github.io/scicookie/guide.html#information-about-the-project
   type: text
   default: https://osl-template.com
   enabled: true
 
 project_license:
-  message: Select the project license
-  help: ""
+  message: Select one option for the project license
+  help: https://osl-incubator.github.io/scicookie/guide.html#information-about-the-project
   type: single-choice
   choices:
     - MIT
@@ -68,8 +68,8 @@ project_license:
   enabled: true
 
 project_layout:
-  message: Select the project layout
-  help: ""
+  message: Select one option for the project layout
+  help: "For more information, check:\n  https://osl-incubator.github.io/scicookie/guide.html#project-layout"
   type: single-choice
   choices:
     - src
@@ -77,8 +77,8 @@ project_layout:
   enabled: false
 
 build_system:
-  message: Select the build system
-  help: ""
+  message: Select one option for the build system
+  help: "For more information, check:\n  https://osl-incubator.github.io/scicookie/guide.html#build-system"
   type: single-choice
   choices:
     - poetry
@@ -92,8 +92,8 @@ build_system:
   enabled: false
 
 command_line_interface:
-  message: Select the Command Line Interface (CLI)
-  help: ""
+  message: Select one option for Command Line Interface (CLI)
+  help: "For more information, check:\n  https://osl-incubator.github.io/scicookie/guide.html#command-line-interfaces-clis"
   type: single-choice
   choices:
     - No command-line interface
@@ -102,8 +102,8 @@ command_line_interface:
   enabled: false
 
 documentation_engine:
-  message: Select the Documentation Engine
-  help: ""
+  message: Select one option for the Documentation Engine
+  help: "For more information, check:\n  https://osl-incubator.github.io/scicookie/guide.html#documentation-engine"
   type: single-choice
   choices:
     - mkdocs
@@ -112,15 +112,15 @@ documentation_engine:
   enabled: false
 
 documentation_url:
-  message: Documentation URL
-  help: ""
+  message: Type the documentation URL
+  help: The URL for the documentation page.
   type: text
   default: ""
   enabled: false
 
 use_tools:
-  message: Select the initial tools you want to add to your project
-  help: ""
+  message: Select all the initial tools you want to add to your project
+  help: "For more information, check:\n  https://osl-incubator.github.io/scicookie/guide.html#project-tools"
   type: multiple-choices
   choices:
     - bandit
@@ -142,8 +142,8 @@ use_tools:
   enabled: false
 
 use_containers:
-  message: Select the container technology for this project
-  help: ""
+  message: Select one option for the container technology for this project
+  help: "For more information, check:\n  https://osl-incubator.github.io/scicookie/guide.html#integration-with-devops-tools"
   type: single-choice
   choices:
     - None
@@ -158,8 +158,8 @@ use_containers:
 #   default: Material
 
 code_of_conduct:
-  message: Select Code of Conduct
-  help: ""
+  message: Select one option for the Code of Conduct
+  help: "For more information, check:\n  https://osl-incubator.github.io/scicookie/guide.html#code-of-conduct"
   type: single-choice
   choices:
     - None
@@ -168,8 +168,8 @@ code_of_conduct:
   enabled: true
 
 governance_document:
-  message: Select a governance document template
-  help: ""
+  message: Select one option for a governance document template
+  help: "For more information, check:\n  https://osl-incubator.github.io/scicookie/guide.html#governance-document"
   type: single-choice
   choices:
     - None
@@ -178,8 +178,8 @@ governance_document:
   enabled: false
 
 roadmap_document:
-  message: Select a Roadmap document template
-  help: ""
+  message: Select one option for a Roadmap document template
+  help: "For more information, check:\n  https://osl-incubator.github.io/scicookie/guide.html#roadmap-document"
   type: single-choice
   choices:
     - None
@@ -195,8 +195,8 @@ roadmap_document:
 #   enabled: false
 
 git_username:
-  message: Git username
-  help: ""
+  message: Type the GIT username
+  help: https://osl-incubator.github.io/scicookie/guide.html#control-version
   type: "text"
   default: zoro_roronoa
   depends_on:
@@ -206,8 +206,8 @@ git_username:
   enabled: false
 
 git_https_origin:
-  message: Git https origin URL
-  help: ""
+  message: Type the GIT HTTPS origin URL
+  help: https://osl-incubator.github.io/scicookie/guide.html#control-version
   type: "text"
   depends_on:
     option: use_git
@@ -216,8 +216,8 @@ git_https_origin:
   enabled: false
 
 git_https_upstream:
-  message: Git https upstream URL
-  help: ""
+  message: Type the GIT HTTPS upstream URL
+  help: https://osl-incubator.github.io/scicookie/guide.html#control-version
   type: "text"
   depends_on:
     option: use_git
@@ -226,8 +226,8 @@ git_https_upstream:
   enabled: false
 
 git_main_branch:
-  message: Git main branch
-  help: ""
+  message: Type the GIT main branch
+  help: https://osl-incubator.github.io/scicookie/guide.html#control-version
   type: "text"
   default: main
   depends_on:

--- a/src/scicookie/ui.py
+++ b/src/scicookie/ui.py
@@ -17,7 +17,6 @@ def _create_question(
         return None
 
     # config required
-    question_message = question.get("message", "")
     question_type = question.get("type", "")
     # todo: implement help text int he prompt
     # question_help = question.get("help")
@@ -39,10 +38,10 @@ def _create_question(
             SciCookieErrorType.SCICOOKIE_INVALID_CONFIGURATION,
         )
 
-    content = {"message": question_message}
+    content = {"message": ""}
 
     if question.get("choices"):
-        content["choices"] = question.get("choices")
+        content["choices"] = question.get("choices", [])
 
     fn_questions: dict[str, Type[inquirer.questions.Question]] = {
         "text": inquirer.Text,
@@ -68,8 +67,9 @@ def make_questions(questions: dict):
         if question_obj:
             default_answer = question.get("default", "")
             default_answer = Template(default_answer).render(answers)
+            message = question.get("message", "")
+            print(f"{message} (default: {default_answer}):")
             print(">> HELP:", question["help"])
-            print(">> DEFAULT:", default_answer)
             answer = inquirer.prompt([question_obj])
 
             # note: if answer is none, it means that the user cancelled
@@ -79,5 +79,4 @@ def make_questions(questions: dict):
             answers[question_id] = (
                 answer.get(question_id, "") or default_answer
             )
-    breakpoint()
     return answers

--- a/src/scicookie/ui.py
+++ b/src/scicookie/ui.py
@@ -1,7 +1,10 @@
 """Define functions for the interface with the user."""
-from typing import Dict, Optional, Type
+from __future__ import annotations
+
+from typing import Optional, Type
 
 import inquirer
+from jinja2 import Template
 
 from scicookie.logs import SciCookieErrorType, SciCookieLogs
 
@@ -14,7 +17,6 @@ def _create_question(
         return None
 
     # config required
-    default_answer = question.get("default", "")
     question_message = question.get("message", "")
     question_type = question.get("type", "")
     # todo: implement help text int he prompt
@@ -37,18 +39,12 @@ def _create_question(
             SciCookieErrorType.SCICOOKIE_INVALID_CONFIGURATION,
         )
 
-    content = {
-        "message": (
-            question_message
-            if not default_answer
-            else f"{question_message} (default: {default_answer})"
-        )
-    }
+    content = {"message": question_message}
 
     if question.get("choices"):
         content["choices"] = question.get("choices")
 
-    fn_questions: Dict[str, Type[inquirer.questions.Question]] = {
+    fn_questions: dict[str, Type[inquirer.questions.Question]] = {
         "text": inquirer.Text,
         "single-choice": inquirer.List,
         "multiple-choices": inquirer.Checkbox,
@@ -63,11 +59,25 @@ def _create_question(
 
 def make_questions(questions: dict):
     """Generate all the enabled questions."""
-    questions_ui = []
+    answers: dict[str, str] = {}
 
     for question_id, question in questions.items():
         question_obj = _create_question(question_id, question)
+        # note: if question_object is None, that means that the question is
+        #       not enabled
         if question_obj:
-            questions_ui.append(question_obj)
+            default_answer = question.get("default", "")
+            default_answer = Template(default_answer).render(answers)
+            print(">> HELP:", question["help"])
+            print(">> DEFAULT:", default_answer)
+            answer = inquirer.prompt([question_obj])
 
-    return inquirer.prompt(questions_ui)
+            # note: if answer is none, it means that the user cancelled
+            #       the process.
+            if answer is None:
+                return {}
+            answers[question_id] = (
+                answer.get(question_id, "") or default_answer
+            )
+    breakpoint()
+    return answers


### PR DESCRIPTION
## Pull Request description
<!-- Describe the purpose of your PR and the changes you have made. -->

* Adds the help information in the TUI for each question;
* Allow using jinja2 tags for `default` value for each question.

I am planning for my next step to move from inquirer to survey, but I need to do more tests to see if that would fix the issues with the input for long texts. Also, if necessary, we can combine both survey  and inquirer. I am still investigating that.


<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #004
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

* ```...```

<!-- Modify the options to suit your project. -->
## Pull Request checklists

This PR is a:
- [ ] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:
- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
