### PR TITLE
Add a dynamic version attribute for the `setuptools` build-backend

### DIFF
--- a/src/scicookie/{{cookiecutter.project_slug}}/build-system/setuptools-pyproject.toml
+++ b/src/scicookie/{{cookiecutter.project_slug}}/build-system/setuptools-pyproject.toml
@@ -110,6 +110,9 @@ dependencies = [
 {% endif %}
 ]
 
+[tool.setuptools.dynamic]
+version = {attr = "{{ cookiecutter.project_slug }}.__version__"}
+
 [project.urls]
 Homepage = "{{ cookiecutter.project_url }}"
 "Bug Tracker" = "{{ cookiecutter.project_url }}/issues"


### PR DESCRIPTION
## Pull Request description

The template for the `setuptools` build-backend had an issue where the project version was declared as a dynamic attribute but the associated `pyproject.toml` file did not contain a `[tool.setuptools.dynamic]` TOML table. This caused the version to be returned as `0.0.0`, instead of the correct version being read from the specified file.

Closes #187


## How to test these changes

* Create a new package and choose `setuptools`, and the following code snippet

```python
from importlib.metadata import version
print(version("mypackage"))
```

should return the default string (`0.1.0`) instead of the current (incorrect) `0.0.0`.


<!-- Modify the options to suit your project. -->
## Pull Request checklists

This PR is a:
- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:
- [ ] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [x] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

N/A

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
