### PR TITLE
Update local development setup instructions in CONTRIBUTING.md and template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,36 +54,48 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
 
 1.  Fork the `scicookie` repo on GitHub.
 
-2.  Clone your fork locally::
-
-    $ git clone git@github.com:your_name_here/scicookie.git
-
+2.  Clone your fork locally:
+    ```
+    git clone git@github.com:your_name_here/scicookie.git
+    ```
 3.  Install your local copy into a virtualenv. Assuming you have
     virtualenvwrapper installed, this is how you set up your fork for
-    local development::
+    local development and this will automatically install all required and `dev` dependencies: 
+    ```
+    mkvirtualenv scicookie
+    cd scicookie
+    ```
+    Using poetry:
+    ```
+    poetry install --with dev
+    ```
+    To get poetry, just pip install it into your virtualenv.
 
-    $ mkvirtualenv scicookie
-    $ cd scicookie/
-    $ python setup.py develop
-
-4.  Create a branch for local development::
-
-    $ git checkout -b name-of-your-bugfix-or-feature
-
+    Alternatively, using pip:
+    ```
+    pip install -e .
+    ```
+4.  Create a branch for local development:
+    ```
+    git checkout -b name-of-your-bugfix-or-feature
+    ```
     Now you can make your changes locally.
 
 5.  When you’re done making changes, check that your changes pass flake8
-    and the tests, including testing other Python versions with tox::
-
-    $ flake8 scicookie tests $ python setup.py
-    test or pytest $ tox
-
+    and the tests, including testing other Python versions with tox:
+    ```
+    flake8 scicookie tests 
+    pytest 
+    tox
+    ```
     To get flake8 and tox, just pip install them into your virtualenv.
 
-6.  Commit your changes and push your branch to GitHub::
-
-    $ git add . $ git commit -m “Your detailed description of your
-    changes.” $ git push origin name-of-your-bugfix-or-feature
+6.  Commit your changes and push your branch to GitHub:
+    ```
+    git add . 
+    git commit -m “Your detailed description of your changes.” 
+    git push origin name-of-your-bugfix-or-feature
+    ```
 
 7.  Submit a pull request through the GitHub website.
 
@@ -102,7 +114,7 @@ Before you submit a pull request, check that it meets these guidelines:
 To run a subset of tests::
 
 ```
-$ pytest
+pytest
 ```
 
 ## Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,12 +58,11 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
     ```
     git clone git@github.com:your_name_here/scicookie.git
     ```
-3.  Install your local copy into a virtualenv. Assuming you have
-    virtualenvwrapper installed, this is how you set up your fork for
+3.  Install your local copy into a virtualenv. This is how you set up your fork for
     local development and this will automatically install all required and `dev` dependencies: 
     ```
-    mkvirtualenv scicookie
     cd scicookie
+    python -m venv env
     ```
     Using poetry:
     ```
@@ -81,14 +80,22 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
     ```
     Now you can make your changes locally.
 
-5.  When you’re done making changes, check that your changes pass flake8
-    and the tests, including testing other Python versions with tox:
+5.  `scicookie` uses a set of `pre-commit` hooks and the `pre-commit` bot to format,
+    type-check, and prettify the codebase. The hooks can be installed locally
+    using -
     ```
-    flake8 scicookie tests 
-    pytest 
-    tox
+    pre-commit install
     ```
-    To get flake8 and tox, just pip install them into your virtualenv.
+
+    This would run the checks every time a commit is created locally. The checks
+    will only run on the files modified by that commit, but the checks can be
+    triggered for all the files using -
+    ```
+    pre-commit run --all-files
+    ```
+
+    If you would like to skip the failing checks and push the code for further
+    discussion, use the `--no-verify` option with `git commit`.
 
 6.  Commit your changes and push your branch to GitHub:
     ```
@@ -111,10 +118,9 @@ Before you submit a pull request, check that it meets these guidelines:
 
 ## Tips
 
-To run a subset of tests::
-
+To run a subset of tests:
 ```
-pytest
+pytest tests.<the test to run>
 ```
 
 ## Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,13 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
     If you would like to skip the failing checks and push the code for further
     discussion, use the `--no-verify` option with `git commit`.
 
+    Smoke tests can be executed locally to quickly verify basic functionality and
+    behavior of the code changes. To run smoke tests, use:
+    ```
+    makim tests.smoke
+    ```
+    Make sure to run comprehensive unit tests alongside smoke tests to maintain code integrity.
+
 6. `scicookie` is tested with `pytest`. `pytest` is responsible for
     testing the code, whose configuration is available in pyproject.toml.
     Additionally, `scicookie` also uses `pytest-cov` to calculate the coverage of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,14 +97,38 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
     If you would like to skip the failing checks and push the code for further
     discussion, use the `--no-verify` option with `git commit`.
 
-6.  Commit your changes and push your branch to GitHub:
+6. `scicookie` is tested with `pytest`. `pytest` is responsible for
+    testing the code, whose configuration is available in pyproject.toml.
+    Additionally, `scicookie` also uses `pytest-cov` to calculate the coverage of
+    these unit tests.
+
+    #### Running tests locally
+
+    The tests can be executed using the `test` dependencies of `scicookie` in the
+    following way -
+    ```
+    python -m pytest
+    ```
+
+    #### Running tests with coverage locally
+
+    The coverage value can be obtained while running the tests using `pytest-cov` in
+    the following way -
+    ```
+    python -m pytest --cov=scicookie tests/
+    ```
+
+    A much more detailed guide on testing with `pytest` is available
+    [here](https://docs.pytest.org/en/8.0.x/how-to/index.html).
+
+7.  Commit your changes and push your branch to GitHub:
     ```
     git add . 
     git commit -m “Your detailed description of your changes.” 
     git push origin name-of-your-bugfix-or-feature
     ```
 
-7.  Submit a pull request through the GitHub website.
+8.  Submit a pull request through the GitHub website.
 
 ## Pull Request Guidelines
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -54,36 +54,48 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
 
 1.  Fork the `scicookie` repo on GitHub.
 
-2.  Clone your fork locally::
-
-    $ git clone git@github.com:your_name_here/scicookie.git
-
+2.  Clone your fork locally:
+    ```
+    git clone git@github.com:your_name_here/scicookie.git
+    ```
 3.  Install your local copy into a virtualenv. Assuming you have
     virtualenvwrapper installed, this is how you set up your fork for
-    local development::
+    local development and this will automatically install all required and `dev` dependencies: 
+    ```
+    mkvirtualenv scicookie
+    cd scicookie
+    ```
+    Using poetry:
+    ```
+    poetry install --with dev
+    ```
+    To get poetry, just pip install it into your virtualenv.
 
-    $ mkvirtualenv scicookie
-    $ cd scicookie/
-    $ python setup.py develop
-
-4.  Create a branch for local development::
-
-    $ git checkout -b name-of-your-bugfix-or-feature
-
+    Alternatively, using pip:
+    ```
+    pip install -e .
+    ```
+4.  Create a branch for local development:
+    ```
+    git checkout -b name-of-your-bugfix-or-feature
+    ```
     Now you can make your changes locally.
 
 5.  When you’re done making changes, check that your changes pass flake8
-    and the tests, including testing other Python versions with tox::
-
-    $ flake8 scicookie tests $ python setup.py
-    test or pytest $ tox
-
+    and the tests, including testing other Python versions with tox:
+    ```
+    flake8 scicookie tests 
+    pytest 
+    tox
+    ```
     To get flake8 and tox, just pip install them into your virtualenv.
 
-6.  Commit your changes and push your branch to GitHub::
-
-    $ git add . $ git commit -m “Your detailed description of your
-    changes.” $ git push origin name-of-your-bugfix-or-feature
+6.  Commit your changes and push your branch to GitHub:
+    ```
+    git add . 
+    git commit -m “Your detailed description of your changes.” 
+    git push origin name-of-your-bugfix-or-feature
+    ```
 
 7.  Submit a pull request through the GitHub website.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,12 +58,11 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
     ```
     git clone git@github.com:your_name_here/scicookie.git
     ```
-3.  Install your local copy into a virtualenv. Assuming you have
-    virtualenvwrapper installed, this is how you set up your fork for
+3.  Install your local copy into a virtualenv. This is how you set up your fork for
     local development and this will automatically install all required and `dev` dependencies: 
     ```
-    mkvirtualenv scicookie
     cd scicookie
+    python -m venv env
     ```
     Using poetry:
     ```
@@ -81,14 +80,22 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
     ```
     Now you can make your changes locally.
 
-5.  When you’re done making changes, check that your changes pass flake8
-    and the tests, including testing other Python versions with tox:
+5.  `scicookie` uses a set of `pre-commit` hooks and the `pre-commit` bot to format,
+    type-check, and prettify the codebase. The hooks can be installed locally
+    using -
     ```
-    flake8 scicookie tests 
-    pytest 
-    tox
+    pre-commit install
     ```
-    To get flake8 and tox, just pip install them into your virtualenv.
+
+    This would run the checks every time a commit is created locally. The checks
+    will only run on the files modified by that commit, but the checks can be
+    triggered for all the files using -
+    ```
+    pre-commit run --all-files
+    ```
+
+    If you would like to skip the failing checks and push the code for further
+    discussion, use the `--no-verify` option with `git commit`.
 
 6.  Commit your changes and push your branch to GitHub:
     ```
@@ -111,10 +118,9 @@ Before you submit a pull request, check that it meets these guidelines:
 
 ## Tips
 
-To run a subset of tests::
-
+To run a subset of tests:
 ```
-$ pytest tests.test_scicookie
+pytest tests.<the test to run>
 ```
 
 ## Release

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -97,6 +97,13 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
     If you would like to skip the failing checks and push the code for further
     discussion, use the `--no-verify` option with `git commit`.
 
+    Smoke tests can be executed locally to quickly verify basic functionality and
+    behavior of the code changes. To run smoke tests, use:
+    ```
+    makim tests.smoke
+    ```
+    Make sure to run comprehensive unit tests alongside smoke tests to maintain code integrity.
+
 6. `scicookie` is tested with `pytest`. `pytest` is responsible for
     testing the code, whose configuration is available in pyproject.toml.
     Additionally, `scicookie` also uses `pytest-cov` to calculate the coverage of

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -97,14 +97,38 @@ Ready to contribute? Here’s how to set up `scicookie` for local development.
     If you would like to skip the failing checks and push the code for further
     discussion, use the `--no-verify` option with `git commit`.
 
-6.  Commit your changes and push your branch to GitHub:
+6. `scicookie` is tested with `pytest`. `pytest` is responsible for
+    testing the code, whose configuration is available in pyproject.toml.
+    Additionally, `scicookie` also uses `pytest-cov` to calculate the coverage of
+    these unit tests.
+
+    #### Running tests locally
+
+    The tests can be executed using the `test` dependencies of `scicookie` in the
+    following way -
+    ```
+    python -m pytest
+    ```
+
+    #### Running tests with coverage locally
+
+    The coverage value can be obtained while running the tests using `pytest-cov` in
+    the following way -
+    ```
+    python -m pytest --cov=scicookie tests/
+    ```
+
+    A much more detailed guide on testing with `pytest` is available
+    [here](https://docs.pytest.org/en/8.0.x/how-to/index.html).
+
+7.  Commit your changes and push your branch to GitHub:
     ```
     git add . 
     git commit -m “Your detailed description of your changes.” 
     git push origin name-of-your-bugfix-or-feature
     ```
 
-7.  Submit a pull request through the GitHub website.
+8.  Submit a pull request through the GitHub website.
 
 ## Pull Request Guidelines
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1370,13 +1370,13 @@ test = ["coverage", "jupyter-server (>=2.0.0)", "pytest (>=7.0)", "pytest-cov", 
 
 [[package]]
 name = "jupyterlab"
-version = "4.0.9"
+version = "4.0.11"
 description = "JupyterLab computational environment"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyterlab-4.0.9-py3-none-any.whl", hash = "sha256:9f6f8e36d543fdbcc3df961a1d6a3f524b4a4001be0327a398f68fa4e534107c"},
-    {file = "jupyterlab-4.0.9.tar.gz", hash = "sha256:9ebada41d52651f623c0c9f069ddb8a21d6848e4c887d8e5ddc0613166ed5c0b"},
+    {file = "jupyterlab-4.0.11-py3-none-any.whl", hash = "sha256:536bf0e78723153a5016ca7efb88ed0ecd7070d3f1555d5b0e2770658f900a3c"},
+    {file = "jupyterlab-4.0.11.tar.gz", hash = "sha256:d1aec24712566bc25a36229788242778e498ca4088028e2f9aa156b8b7fdc8fc"},
 ]
 
 [package.dependencies]
@@ -1396,7 +1396,7 @@ tornado = ">=6.2.0"
 traitlets = "*"
 
 [package.extras]
-dev = ["black[jupyter] (==23.10.1)", "build", "bump2version", "coverage", "hatch", "pre-commit", "pytest-cov", "ruff (==0.1.4)"]
+dev = ["build", "bump2version", "coverage", "hatch", "pre-commit", "pytest-cov", "ruff (==0.1.6)"]
 docs = ["jsx-lexer", "myst-parser", "pydata-sphinx-theme (>=0.13.0)", "pytest", "pytest-check-links", "pytest-tornasync", "sphinx (>=1.8,<7.2.0)", "sphinx-copybutton"]
 docs-screenshots = ["altair (==5.0.1)", "ipython (==8.14.0)", "ipywidgets (==8.0.6)", "jupyterlab-geojson (==3.4.0)", "jupyterlab-language-pack-zh-cn (==4.0.post0)", "matplotlib (==3.7.1)", "nbconvert (>=7.0.0)", "pandas (==2.0.2)", "scipy (==1.10.1)", "vega-datasets (==0.9.0)"]
 test = ["coverage", "pytest (>=7.0)", "pytest-check-links (>=0.7)", "pytest-console-scripts", "pytest-cov", "pytest-jupyter (>=0.5.3)", "pytest-timeout", "pytest-tornasync", "requests", "requests-cache", "virtualenv"]
@@ -1542,6 +1542,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -2103,6 +2113,7 @@ description = "A docutils backend for pybtex."
 optional = false
 python-versions = ">=3.7"
 files = [
+    {file = "pybtex-docutils-1.0.3.tar.gz", hash = "sha256:3a7ebdf92b593e00e8c1c538aa9a20bca5d92d84231124715acc964d51d93c6b"},
     {file = "pybtex_docutils-1.0.3-py3-none-any.whl", hash = "sha256:8fd290d2ae48e32fcb54d86b0efb8d573198653c7e2447d5bec5847095f430b9"},
 ]
 
@@ -2360,6 +2371,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
+++ b/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
@@ -164,14 +164,38 @@ Ready to contribute? Here’s how to set up `{{ cookiecutter.project_slug}}` for
     If you would like to skip the failing checks and push the code for further
     discussion, use the `--no-verify` option with `git commit`.
 
-6.  Commit your changes and push your branch to GitHub::
+6. `{{ cookiecutter.project_slug }}` is tested with `pytest`. `pytest` is responsible for
+    testing the code, whose configuration is available in pyproject.toml.
+    Additionally, `{{ cookiecutter.project_slug }}` also uses `pytest-cov` to calculate the coverage of
+    these unit tests.
+
+    #### Running tests locally
+
+    The tests can be executed using the `test` dependencies of `{{ cookiecutter.project_slug }}` in the
+    following way -
+    ```
+    python -m pytest
+    ```
+
+    #### Running tests with coverage locally
+
+    The coverage value can be obtained while running the tests using `pytest-cov` in
+    the following way -
+    ```
+    python -m pytest --cov={{ cookiecutter.project_slug }} tests/
+    ```
+
+    A much more detailed guide on testing with `pytest` is available
+    [here](https://docs.pytest.org/en/8.0.x/how-to/index.html).
+
+7.  Commit your changes and push your branch to GitHub::
     ```
     git add . 
     git commit -m “Your detailed description of your changes.” 
     git push origin name-of-your-bugfix-or-feature
     ```
 
-7.  Submit a pull request through the GitHub website.
+8.  Submit a pull request through the GitHub website.
 
 ## Pull Request Guidelines
 

--- a/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
+++ b/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
@@ -119,36 +119,50 @@ Ready to contribute? Here’s how to set up `{{ cookiecutter.project_slug}}` for
 
 1.  Fork the `{{ cookiecutter.project_slug }}` repo on GitHub.
 
-2.  Clone your fork locally::
-
-    $ git clone git@github.com:your_name_here/{{ cookiecutter.project_slug }}.git
+2.  Clone your fork locally:
+    ```
+    git clone git@github.com:your_name_here/{{ cookiecutter.project_slug }}.git
+    ```
 
 3.  Install your local copy into a virtualenv. Assuming you have
     virtualenvwrapper installed, this is how you set up your fork for
-    local development::
+    local development:
+    ```
+    mkvirtualenv {{ cookiecutter.project_slug }}
+    cd {{cookiecutter.project_slug }}/
+    ```
+    Using poetry:
+    ```
+    poetry install --with dev
+    ```
+    To get poetry, just pip install it into your virtualenv.
 
-    $ mkvirtualenv {{ cookiecutter.project_slug }}
-    $ cd {{cookiecutter.project_slug }}/
-    $ python setup.py develop
+    Alternatively, using pip:
+    ```
+    pip install -e .
+    ```
 
-4.  Create a branch for local development::
-
-    $ git checkout -b name-of-your-bugfix-or-feature
-
+4.  Create a branch for local development:
+    ```
+    git checkout -b name-of-your-bugfix-or-feature
+    ```
     Now you can make your changes locally.
 
 5.  When you’re done making changes, check that your changes pass flake8
-    and the tests, including testing other Python versions with tox::
-
-    $ make lint
-    $ make test
-
+    and the tests, including testing other Python versions with tox:
+    ```
+    flake8 {{ cookiecutter.project_slug }} tests 
+    pytest 
+    tox
+    ```
     To get flake8 and tox, just pip install them into your virtualenv.
 
 6.  Commit your changes and push your branch to GitHub::
-
-    $ git add . $ git commit -m “Your detailed description of your
-    changes.” $ git push origin name-of-your-bugfix-or-feature
+    ```
+    git add . 
+    git commit -m “Your detailed description of your changes.” 
+    git push origin name-of-your-bugfix-or-feature
+    ```
 
 7.  Submit a pull request through the GitHub website.
 
@@ -167,7 +181,7 @@ Before you submit a pull request, check that it meets these guidelines:
 To run a subset of tests::
 {% if cookiecutter.use_pytest == "yes" -%}
 ```
-$ pytest tests.test_{{ cookiecutter.package_slug }}
+pytest tests.test_{{ cookiecutter.package_slug }}
 ```
 {%- endif %}
 {% if cookiecutter.use_hypothesis == "yes" -%}

--- a/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
+++ b/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
@@ -164,6 +164,13 @@ Ready to contribute? Here’s how to set up `{{ cookiecutter.project_slug}}` for
     If you would like to skip the failing checks and push the code for further
     discussion, use the `--no-verify` option with `git commit`.
 
+    Smoke tests can be executed locally to quickly verify basic functionality and
+    behavior of the code changes. To run smoke tests, use:
+    ```
+    makim tests.smoke
+    ```
+    Make sure to run comprehensive unit tests alongside smoke tests to maintain code integrity.
+
 6. `{{ cookiecutter.project_slug }}` is tested with `pytest`. `pytest` is responsible for
     testing the code, whose configuration is available in pyproject.toml.
     Additionally, `{{ cookiecutter.project_slug }}` also uses `pytest-cov` to calculate the coverage of

--- a/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
+++ b/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
@@ -164,13 +164,6 @@ Ready to contribute? Here’s how to set up `{{ cookiecutter.project_slug}}` for
     If you would like to skip the failing checks and push the code for further
     discussion, use the `--no-verify` option with `git commit`.
 
-    Smoke tests can be executed locally to quickly verify basic functionality and
-    behavior of the code changes. To run smoke tests, use:
-    ```
-    makim tests.smoke
-    ```
-    Make sure to run comprehensive unit tests alongside smoke tests to maintain code integrity.
-
 6. `{{ cookiecutter.project_slug }}` is tested with `pytest`. `pytest` is responsible for
     testing the code, whose configuration is available in pyproject.toml.
     Additionally, `{{ cookiecutter.project_slug }}` also uses `pytest-cov` to calculate the coverage of

--- a/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
+++ b/src/scicookie/{{cookiecutter.project_slug}}/docs/contributing.md
@@ -124,12 +124,11 @@ Ready to contribute? Here’s how to set up `{{ cookiecutter.project_slug}}` for
     git clone git@github.com:your_name_here/{{ cookiecutter.project_slug }}.git
     ```
 
-3.  Install your local copy into a virtualenv. Assuming you have
-    virtualenvwrapper installed, this is how you set up your fork for
+3.  Install your local copy into a virtualenv. This is how you set up your fork for
     local development:
     ```
-    mkvirtualenv {{ cookiecutter.project_slug }}
     cd {{cookiecutter.project_slug }}/
+    python -m venv env
     ```
     Using poetry:
     ```
@@ -148,14 +147,22 @@ Ready to contribute? Here’s how to set up `{{ cookiecutter.project_slug}}` for
     ```
     Now you can make your changes locally.
 
-5.  When you’re done making changes, check that your changes pass flake8
-    and the tests, including testing other Python versions with tox:
+5.  `{{ cookiecutter.project_slug }}` uses a set of `pre-commit` hooks and the `pre-commit` bot to format,
+    type-check, and prettify the codebase. The hooks can be installed locally
+    using -
     ```
-    flake8 {{ cookiecutter.project_slug }} tests 
-    pytest 
-    tox
+    pre-commit install
     ```
-    To get flake8 and tox, just pip install them into your virtualenv.
+
+    This would run the checks every time a commit is created locally. The checks
+    will only run on the files modified by that commit, but the checks can be
+    triggered for all the files using -
+    ```
+    pre-commit run --all-files
+    ```
+
+    If you would like to skip the failing checks and push the code for further
+    discussion, use the `--no-verify` option with `git commit`.
 
 6.  Commit your changes and push your branch to GitHub::
     ```
@@ -178,7 +185,7 @@ Before you submit a pull request, check that it meets these guidelines:
 
 ## Tips
 
-To run a subset of tests::
+To run a subset of tests:
 {% if cookiecutter.use_pytest == "yes" -%}
 ```
 pytest tests.test_{{ cookiecutter.package_slug }}


### PR DESCRIPTION
## Pull Request description
This pull request updates the CONTRIBUTING file for scicookie and the template to provide accurate and up-to-date instructions for setting up the project locally. The previous instructions were outdated and misleading, as they referenced a setup.py file that does not exist in the repository.

Changes Made:

Updated the CONTRIBUTING.md with clear and concise instructions for local development setup.
Removed references to the nonexistent setup.py file.
Provided alternative installation methods such as Poetry (poetry install) and pip (pip install -e .).
Replaced `$` with Code Blocks
Fixed Issue in template where instructions said tox and flake8 but referenced `make lint` and `make tests`

 Fixes #203 

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

* ```...```

<!-- Modify the options to suit your project. -->
## Pull Request checklists

This PR is a:
- [ ] bug-fix
- [ ] new feature
- [x] maintenance

About this PR:
- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
