### PR TITLE
fix: Fix the default slug used for the package name

### DIFF
--- a/src/scicookie/cli.py
+++ b/src/scicookie/cli.py
@@ -3,8 +3,8 @@
 import argparse
 import json
 import os
-import sys
 import re
+import sys
 
 from pathlib import Path
 from typing import Union
@@ -129,15 +129,16 @@ def call_cookiecutter(profile: Profile, answers: dict):  # noqa: PLR0912
             f"Process {pid} killed.", SciCookieErrorType.SH_KEYBOARD_INTERRUPT
         )
 
+
 def sanitize_slugs(answers: dict[str, str]) -> dict[str, str]:
-    """Sanitize the project slug by removing 
-    non-alphanumeric characters."""
+    """Sanitize the project slug by removing non-alphanumeric characters."""
     sanitized_answers = answers.copy()
     for key in ["package_slug"]:
         slug = sanitized_answers.get(key, "")
-        sanitized_slug = re.sub(r'[^a-zA-Z0-9_]', '', slug)
+        sanitized_slug = re.sub(r"[^a-zA-Z0-9_]", "", slug)
         sanitized_answers[key] = sanitized_slug
     return sanitized_answers
+
 
 def app():
     """Run SciCookie."""

--- a/src/scicookie/cli.py
+++ b/src/scicookie/cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import sys
+import re
 
 from pathlib import Path
 from typing import Union
@@ -128,6 +129,15 @@ def call_cookiecutter(profile: Profile, answers: dict):  # noqa: PLR0912
             f"Process {pid} killed.", SciCookieErrorType.SH_KEYBOARD_INTERRUPT
         )
 
+def sanitize_slugs(answers: dict[str, str]) -> dict[str, str]:
+    """Sanitize the project slug by removing 
+    non-alphanumeric characters."""
+    sanitized_answers = answers.copy()
+    for key in ["package_slug"]:
+        slug = sanitized_answers.get(key, "")
+        sanitized_slug = re.sub(r'[^a-zA-Z0-9_]', '', slug)
+        sanitized_answers[key] = sanitized_slug
+    return sanitized_answers
 
 def app():
     """Run SciCookie."""
@@ -163,6 +173,8 @@ def app():
     profile = Profile(args.profile)
 
     answers = make_questions(profile.config)
+
+    answers = sanitize_slugs(answers)
 
     if not answers:
         return

--- a/src/scicookie/cli.py
+++ b/src/scicookie/cli.py
@@ -3,7 +3,6 @@
 import argparse
 import json
 import os
-import re
 import sys
 
 from pathlib import Path
@@ -130,16 +129,6 @@ def call_cookiecutter(profile: Profile, answers: dict):  # noqa: PLR0912
         )
 
 
-def sanitize_slugs(answers: dict[str, str]) -> dict[str, str]:
-    """Sanitize the project slug by removing non-alphanumeric characters."""
-    sanitized_answers = answers.copy()
-    for key in ["package_slug"]:
-        slug = sanitized_answers.get(key, "")
-        sanitized_slug = re.sub(r"[^a-zA-Z0-9_]", "", slug)
-        sanitized_answers[key] = sanitized_slug
-    return sanitized_answers
-
-
 def app():
     """Run SciCookie."""
     # note: this parameter should be provided by a CLI argument
@@ -174,8 +163,6 @@ def app():
     profile = Profile(args.profile)
 
     answers = make_questions(profile.config)
-
-    answers = sanitize_slugs(answers)
 
     if not answers:
         return

--- a/src/scicookie/profiles/base.yaml
+++ b/src/scicookie/profiles/base.yaml
@@ -37,7 +37,7 @@ package_slug:
   message: Type the code name for your package (the name used to import your package)
   help: https://osl-incubator.github.io/scicookie/guide/#information-about-the-project
   type: text
-  default: "{{project_slug.replace('-', '_')}}"
+  default: "{{project_slug.replace('-', '_') | sanitize_package_slug}} "
   visible: true
 
 project_version:

--- a/src/scicookie/ui.py
+++ b/src/scicookie/ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-import re  # Add this import for regex
+import re
 
 from typing import Any, Optional, Type
 
@@ -105,7 +105,7 @@ def make_questions(questions: dict[str, Any]) -> dict[str, str]:
     print("." * columns)
 
     # Create a Jinja2 environment and add the custom filter
-    env = Environment(autoescape=True)
+    env = Environment()
     env.filters["sanitize_package_slug"] = sanitize_package_slug
 
     for question_id, question in questions.items():


### PR DESCRIPTION
I added a function to sanitize the `package_slug`. So, now, It will remove the non-alphanumeric characters from the `package_slug` and will not give error.

Solves #197 