### PR TITLE
ci: ensure linter runs irrespective of previous step's outcome

### DIFF
--- a/src/scicookie/{{cookiecutter.project_slug}}/.github/workflows/main.yaml
+++ b/src/scicookie/{{cookiecutter.project_slug}}/.github/workflows/main.yaml
@@ -61,6 +61,7 @@ jobs:
           {%- endif %}
 
       - name: Run style checks
+        if: success() || failure()
         run: |
           pre-commit install
           {%- if cookiecutter.use_makim == "yes" %}


### PR DESCRIPTION
## Pull Request description
Modified the workflow configuration to ensure that the linter runs regardless of the outcome of the previous step. Previously, the linter was only running if the previous step succeeded, but this change allows it to execute even if the previous step failed.

Fixes #58 

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
