### PR TITLE
Add: pyos profile to cookie

### DIFF
--- a/src/scicookie/profiles/pyos.yaml
+++ b/src/scicookie/profiles/pyos.yaml
@@ -1,0 +1,92 @@
+author_full_name:
+  default: Your Name
+  visible: true
+
+author_email:
+  default: your.email@email.com
+  visible: true
+
+project_name:
+  default: Your Project Name Here
+  visible: true
+
+project_short_description:
+  visible: true
+
+project_slug:
+  visible: false
+
+package_slug:
+  visible: false
+
+project_version:
+  default: 0.1.0
+  visible: false
+
+project_url:
+  visible: false
+
+project_license:
+  # first choice is the default for the UI
+  default: MIT
+  visible: false
+
+project_layout:
+  default: src
+  visible: false
+
+build_system:
+  visible: false
+  default: hatch
+
+command_line_interface:
+  visible: false
+
+documentation_engine:
+  visible: true
+  choices:
+    - sphinx
+    - mkdocs
+
+documentation_url:
+  visible: false
+
+use_tools:
+  choices:
+    - conda
+    - coverage
+    - ruff
+    - mypy
+    - pre-commit
+    - pytest
+  visible: true
+
+use_containers:
+  visible: false
+
+code_of_conduct:
+  choices:
+    - contributor-covenant
+  visible: false
+
+governance_document:
+  default: None
+  visible: false
+
+roadmap_document:
+  default: None
+  visible: false
+
+git_username:
+  default: yorbriar
+  visible: true
+
+git_https_origin:
+  default: ""
+  visible: false
+
+git_https_upstream:
+  visible: false
+
+git_main_branch:
+  visible: false


### PR DESCRIPTION
## Pull Request description

This is a PR that adds a pyOpenSci profile to the osl cookiecutter!

## How to test these changes

`scicookie --profile pyos`


## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
