### PR TITLE
fix(template): Updating quarto-cli and quartodoc versions and pin griffe version

### DIFF
--- a/src/scicookie/{{cookiecutter.project_slug}}/build-system/base/dev-deps-pyproject.toml
+++ b/src/scicookie/{{cookiecutter.project_slug}}/build-system/base/dev-deps-pyproject.toml
@@ -94,8 +94,9 @@ dev = [
   "pydata-sphinx-theme >= 0.15.3",
   {% endif %}
 {%- elif cookiecutter.documentation_engine == 'quarto' %}
-  "quarto-cli >= 1.4.550",
-  "quartodoc >= 0.7.2",
+  "quarto-cli >= 1.5.56",
+  "quartodoc >= 0.7.5",
+  "griffe = <=0.49.0",
 {%- endif %}
   # 'PosixPath' object has no attribute 'endswith'
   "virtualenv<=20.25.1",

--- a/src/scicookie/{{cookiecutter.project_slug}}/build-system/poetry/pyproject.toml
+++ b/src/scicookie/{{cookiecutter.project_slug}}/build-system/poetry/pyproject.toml
@@ -129,8 +129,9 @@ pydata-sphinx-theme = ">= 0.15.3"
 {% endif %}
 {# keep this line here #}
 {%- elif cookiecutter.documentation_engine == 'quarto' %}
-quarto-cli = ">=1.4.550"
-quartodoc = ">=0.7.2"
+quarto-cli = ">=1.5.56"
+quartodoc = ">=0.7.5"
+griffe = "<=0.49.0"
 {% endif -%}
 {%- if cookiecutter.use_makim == "yes" -%}
 makim = "1.15.1"


### PR DESCRIPTION
## Pull Request description

Recently, `griffe` had been updated. It is cause to get the following error:

`ModuleNotFoundError: No module named 'griffe.loader'`

I restrict the version of `griffe` for it works fine, when `quartodoc` is updated it should be removed.

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved