### PR TITLE
Added new template for communication platform

### DIFF
--- a/src/scicookie/cookiecutter.json
+++ b/src/scicookie/cookiecutter.json
@@ -84,7 +84,13 @@
   "use_circleci": "no",
   "use_azure_pipelines": "no",
   "use_gitlab_ci": "no",
-  "add_communication_tool": "False",
-  "communication_platform": "discord",
+  "communication_platform": [
+    "None",
+    "discord",
+    "discourse",
+    "slack",
+    "zulip",
+    "telegram"
+  ],
   "communication_link": ""
 }

--- a/src/scicookie/profiles/base.yaml
+++ b/src/scicookie/profiles/base.yaml
@@ -303,29 +303,23 @@ continuous_integration:
     - gitlab_ci
   visible: true
 
-add_communication_tool:
-  message: Do you want to add a communication tool?
-  help: https://osl-incubator.github.io/scicookie/guide/#communication-tool
-  type: confirm
-  default: "False"
-  visible: true
-
 communication_platform:
   message: Select the communication platform
   help: https://osl-incubator.github.io/scicookie/guide/#communication-tool
   type: single-choice
-  default: discord
+  default: None
   choices:
+    - None
     - discord
     - discourse
     - slack
     - zulip
     - telegram
-  visible: ${{ add_communication_tool | string == "True" }}
+  visible: true
 
 communication_link:
   message: Type the communication link
   help: https://osl-incubator.github.io/scicookie/guide/#communication-tool
   type: text
   default: ""
-  visible: ${{ add_communication_tool | string == "True" }}
+  visible: ${{ communication_platform != "None" }}

--- a/src/scicookie/profiles/osl.yaml
+++ b/src/scicookie/profiles/osl.yaml
@@ -111,14 +111,17 @@ continuous_integration:
     - github_actions
   visible: false
 
-add_communication_tool:
-  default: "False"
-  visible: true
-
 communication_platform:
-  default: discord
-  visible: ${{ add_communication_tool | string == "True" }}
+  default: None
+  choices:
+    - None
+    - discord
+    - discourse
+    - slack
+    - zulip
+    - telegram
+  visible: true
 
 communication_link:
   default: ""
-  visible: ${{ add_communication_tool | string == "True" }}
+  visible: ${{ communication_platform != "None" }}

--- a/src/scicookie/{{cookiecutter.project_slug}}/README.md
+++ b/src/scicookie/{{cookiecutter.project_slug}}/README.md
@@ -115,7 +115,7 @@
 
 - Documentation: {{ cookiecutter.documentation_url }}
 
-{% if cookiecutter.add_communication_tool | string == "True" -%}
+{% if cookiecutter.communication_platform != "None" %}
 ## Communication
 
 Platform: **{{ cookiecutter.communication_platform }}**

--- a/tests/profiles/test-depends-on.yaml
+++ b/tests/profiles/test-depends-on.yaml
@@ -312,29 +312,23 @@ continuous_integration:
     - gitlab_ci
   visible: true
 
-add_communication_tool:
-  message: Do you want to add a communication tool?
-  help: https://osl-incubator.github.io/scicookie/guide/#communication-tool
-  type: confirm
-  default: "False"
-  visible: true
-
 communication_platform:
   message: Select the communication platform
   help: https://osl-incubator.github.io/scicookie/guide/#communication-tool
   type: single-choice
-  default: discord
+  default: None
   choices:
+    - None
     - discord
     - discourse
     - slack
     - zulip
     - telegram
-  visible: ${{ add_communication_tool == "True" }}
+  visible: true
 
 communication_link:
   message: Type the communication link
   help: https://osl-incubator.github.io/scicookie/guide/#communication-tool
   type: text
   default: ""
-  visible: ${{ add_communication_tool == "True" }}
+  visible: ${{ communication_platform != "None" }}

--- a/tests/profiles/test-main.yaml
+++ b/tests/profiles/test-main.yaml
@@ -308,29 +308,23 @@ continuous_integration:
     - gitlab_ci
   visible: true
 
-add_communication_tool:
-  message: Do you want to add a communication tool?
-  help: https://osl-incubator.github.io/scicookie/guide/#communication-tool
-  type: confirm
-  default: "False"
-  visible: true
-
 communication_platform:
   message: Select the communication platform
   help: https://osl-incubator.github.io/scicookie/guide/#communication-tool
   type: single-choice
-  default: discord
+  default: None
   choices:
+    - None
     - discord
     - discourse
     - slack
     - zulip
     - telegram
-  visible: ${{ add_communication_tool == "True" }}
+  visible: true
 
 communication_link:
   message: Type the communication link
   help: https://osl-incubator.github.io/scicookie/guide/#communication-tool
   type: text
   default: ""
-  visible: ${{ add_communication_tool == "True" }}
+  visible: ${{ communication_platform != "None" }}


### PR DESCRIPTION
### Description

This PR adds support for configuring a communication tool in the generated SciCookie project.

Users can now opt-in to include a Communication section in their README and specify a platform + link for their community channel.

### Supported Platforms

- Discord
- Discourse
- Slack
- Zulip
- Telegram

### What’s Included

Added three new interactive prompts:

- add_communication_tool (boolean)
- communication_platform (single-choice list)
- communication_link (text input)

1. Added conditional rendering of the Communication section in the project’s README.md.
2. Updated cookiecutter.json, profiles/base.yaml, and profiles/osl.yaml to support the new fields.
3. Updated the test suite (test-main.yaml and test-depends-on.yaml) to include the new variables and make sure the CLI tests pass correctly.

### ScreenShots
<img width="918" height="425" alt="Screenshot 2025-11-24 020327" src="https://github.com/user-attachments/assets/1b0a33b5-fb26-4b77-b2df-220fb3c0a0d8" />
<img width="928" height="906" alt="Screenshot 2025-11-24 020350" src="https://github.com/user-attachments/assets/2032dde9-b1e0-4590-9df6-b1c6acfc333b" />
<img width="914" height="154" alt="Screenshot 2025-11-24 020414" src="https://github.com/user-attachments/assets/f80dd940-64e9-4422-a83c-01d70d43d954" />

Issue: #338