### PR TITLE
fix: handle empty cookiecutter default lists

### DIFF
--- a/src/scicookie/cli.py
+++ b/src/scicookie/cli.py
@@ -54,6 +54,7 @@ def _get_cookiecutter_default_answer(
             "Invalid cookiecutter configuration.",
             SciCookieErrorType.SCICOOKIE_INVALID_CONFIGURATION,
         )
+        return ""
 
     if isinstance(answer_definition, str):
         return answer_definition
@@ -65,6 +66,7 @@ def _get_cookiecutter_default_answer(
         "Invalid cookiecutter configuration.",
         SciCookieErrorType.SCICOOKIE_INVALID_CONFIGURATION,
     )
+    return ""
 
 
 def call_cookiecutter(profile: Profile, answers: dict) -> None:

--- a/src/scicookie/cli.py
+++ b/src/scicookie/cli.py
@@ -58,7 +58,13 @@ def _get_cookiecutter_default_answer(
     if isinstance(answer_definition, str):
         return answer_definition
 
-    return answer_definition[0]
+    if answer_definition:
+        return answer_definition[0]
+
+    SciCookieLogs.raise_error(
+        "Invalid cookiecutter configuration.",
+        SciCookieErrorType.SCICOOKIE_INVALID_CONFIGURATION,
+    )
 
 
 def call_cookiecutter(profile: Profile, answers: dict) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ import pytest
 import yaml
 
 from scicookie.cli import _get_cookiecutter_default_answer
-from scicookie.logs import SciCookieErrorType
+from scicookie.logs import SciCookieErrorType as ErrorType
 from scicookie.ui import check_visibility
 
 
@@ -137,7 +137,6 @@ class TestDependsOn(BaseCLITestProfile):
         assert "Traceback" not in output, output
 
 
-
 def test_get_cookiecutter_default_answer_returns_string():
     """Return string defaults unchanged."""
     assert _get_cookiecutter_default_answer("default") == "default"
@@ -152,7 +151,7 @@ def test_get_cookiecutter_default_answer_rejects_empty_list(monkeypatch):
     """Reject empty list defaults as invalid cookiecutter configuration."""
 
     def raise_error(message, message_type):
-        assert message_type == SciCookieErrorType.SCICOOKIE_INVALID_CONFIGURATION
+        assert message_type == ErrorType.SCICOOKIE_INVALID_CONFIGURATION
         raise ValueError(message)
 
     monkeypatch.setattr("scicookie.cli.SciCookieLogs.raise_error", raise_error)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,8 @@ import pexpect
 import pytest
 import yaml
 
+from scicookie.cli import _get_cookiecutter_default_answer
+from scicookie.logs import SciCookieErrorType
 from scicookie.ui import check_visibility
 
 
@@ -133,3 +135,27 @@ class TestDependsOn(BaseCLITestProfile):
         child.expect(pexpect.EOF)
         output = child.before
         assert "Traceback" not in output, output
+
+
+
+def test_get_cookiecutter_default_answer_returns_string():
+    """Return string defaults unchanged."""
+    assert _get_cookiecutter_default_answer("default") == "default"
+
+
+def test_get_cookiecutter_default_answer_returns_first_choice():
+    """Return the first item for list defaults."""
+    assert _get_cookiecutter_default_answer(["first", "second"]) == "first"
+
+
+def test_get_cookiecutter_default_answer_rejects_empty_list(monkeypatch):
+    """Reject empty list defaults as invalid cookiecutter configuration."""
+
+    def raise_error(message, message_type):
+        assert message_type == SciCookieErrorType.SCICOOKIE_INVALID_CONFIGURATION
+        raise ValueError(message)
+
+    monkeypatch.setattr("scicookie.cli.SciCookieLogs.raise_error", raise_error)
+
+    with pytest.raises(ValueError, match="Invalid cookiecutter configuration"):
+        _get_cookiecutter_default_answer([])


### PR DESCRIPTION
## Pull Request description

Handle empty list defaults in `_get_cookiecutter_default_answer`.

Previously, list defaults were handled by directly returning `answer_definition[0]`. If an empty list was provided by configuration, this raised an `IndexError`.

This change treats empty list defaults as invalid cookiecutter configuration and uses the existing SciCookie error handler.

## How to test these changes

- `python -m py_compile src/scicookie/cli.py tests/test_cli.py`
- Optional: `python -m pytest tests/test_cli.py -q`

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.

## Additional information

This is a small robustness fix for invalid cookiecutter configuration handling.